### PR TITLE
Chi 904 fix logon by barcode

### DIFF
--- a/ChiasmaDeposit/BarCodeController.cs
+++ b/ChiasmaDeposit/BarCodeController.cs
@@ -1,44 +1,53 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System;
 using System.Windows.Forms;
+using ChiasmaDeposit.Properties;
+using Molmed.ChiasmaDep;
 
 namespace Molmed.ChiasmaDep.Data
 {
     public delegate void BarCodeEventHandler(String barCode);
 
-    class BarCodeController : ChiasmaDepBase
+    public class BarCodeController : ChiasmaDepBase
     {
-        private String MyBarCodeString;
-        private Boolean MyBarCodeFlag;
-        private DateTime MyBarCodeReadTime;
-        private Form MyForm;
+        private String _barCodeString;
+        private Boolean _barCodeFlag;
+        private DateTime _barCodeReadTime;
+        private readonly System.Timers.Timer _activityTimer;
 
         public event BarCodeEventHandler BarCodeReceived;
 
         public BarCodeController(Form form)
-            : base()
         {
-            MyForm = form;
-            MyBarCodeFlag = false;
-            MyBarCodeString = null;
-            MyForm.KeyPreview = true;
-            MyForm.KeyDown += new KeyEventHandler(Form_KeyDown);
+            _barCodeFlag = false;
+            _barCodeString = null;
+            form.KeyPreview = true;
+            form.KeyDown += Form_KeyDown;
+            QuitAtInternalBarcodeLength = true;
+            _activityTimer = new System.Timers.Timer {Interval = 200};
+            _activityTimer.Elapsed += ActivityTimer_Elapsed;
+            _activityTimer.Enabled = false;
+
+        }
+
+        private bool QuitAtInternalBarcodeLength { get; }
+
+        private void ActivityTimer_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
+        {
+            BarCodeReceived?.Invoke(_barCodeString);
         }
 
         private void Form_KeyDown(object sender, KeyEventArgs e)
         {
-            TimeSpan elapsedTime;
-
-            if (MyBarCodeFlag)
+            if (_barCodeFlag)
             {
                 // Check how long it was since the bar code reading began.
-                elapsedTime = DateTime.Now.Subtract(MyBarCodeReadTime);
+                var elapsedTime = DateTime.Now.Subtract(_barCodeReadTime);
                 // If it was more than two secondes ago, it is probably a manual input
                 // and should not be regarded as a bar code reading.
-                if (elapsedTime.Seconds > BarCodeManager.GetMaxTimeToRead())
+
+                if (elapsedTime.Seconds > Settings.Default.BarCodeMaxTimeToRead)
                 {
-                    MyBarCodeFlag = false;
+                    _barCodeFlag = false;
                 }
             }
 
@@ -54,30 +63,29 @@ namespace Molmed.ChiasmaDep.Data
                 case Keys.D7:
                 case Keys.D8:
                 case Keys.D9:
-                    if (!MyBarCodeFlag)
+                    if (!_barCodeFlag)
                     {
                         // Start saving digits.
-                        MyBarCodeFlag = true;
-                        MyBarCodeReadTime = DateTime.Now;
-                        MyBarCodeString = "";
+                        _barCodeFlag = true;
+                        _barCodeReadTime = DateTime.Now;
+                        _barCodeString = "";
                     }
                     // Add digit.
-                    MyBarCodeString += e.KeyCode.ToString().Substring(1);
+                    _barCodeString += e.KeyCode.ToString().Substring(1);
+
+                    if (QuitAtInternalBarcodeLength &&
+                        _barCodeString.Length == Settings.Default.BarCodeLengthInternal &&
+                        IsNotNull(BarCodeReceived))
+                    {
+                        // Make a break to read the last termination character (if any) before barcode-received event
+                        //BarCodeReceived(MyBarCodeString);
+                        _activityTimer.Enabled = true;
+                    }
+
                     break;
 
-                case Keys.Enter:
-                    if (MyBarCodeFlag)
-                    {
-                        // Fire bar code received event.
-                        if (IsNotNull(BarCodeReceived))
-                        {
-                            BarCodeReceived(MyBarCodeString);
-                        }
-                    }
-                    MyBarCodeFlag = false;
-                    break;
                 default:
-                    MyBarCodeFlag = false;
+                    _barCodeFlag = false;
                     break;
             }
         }

--- a/ChiasmaDeposit/ChiasmaDeposit.csproj
+++ b/ChiasmaDeposit/ChiasmaDeposit.csproj
@@ -141,6 +141,9 @@
       <DependentUpon>LoginDialog.cs</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="LoginWithBarCodeDialog.resx">
+      <DependentUpon>LoginWithBarCodeDialog.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="PrintBarCodeDialog.resx">
       <SubType>Designer</SubType>
       <DependentUpon>PrintBarCodeDialog.cs</DependentUpon>

--- a/ChiasmaDeposit/LoadSampleStorageDuoDialog.cs
+++ b/ChiasmaDeposit/LoadSampleStorageDuoDialog.cs
@@ -16,6 +16,7 @@ using Molmed.ChiasmaDep;
 using Molmed.ChiasmaDep.Data;
 using Molmed.ChiasmaDep.Data.Exception;
 using Molmed.ChiasmaDep.Database;
+using BarCodeEventHandler = Molmed.ChiasmaDep.Data.BarCodeEventHandler;
 
 namespace Molmed.ChiasmaDep.Dialog 
 {

--- a/ChiasmaDeposit/LoginWithBarCodeDialog.Designer.cs
+++ b/ChiasmaDeposit/LoginWithBarCodeDialog.Designer.cs
@@ -71,7 +71,7 @@
             // 
             // BarcodeTextBox
             // 
-            this.BarcodeTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            this.BarcodeTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.BarcodeTextBox.Location = new System.Drawing.Point(15, 114);
             this.BarcodeTextBox.Name = "BarcodeTextBox";
@@ -112,8 +112,9 @@
             this.Controls.Add(this.MyCancelButton);
             this.Controls.Add(this.MyOkButton);
             this.Controls.Add(this.label1);
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "LoginWithBarcodeDialog";
-            this.Text = "Login OrderMan";
+            this.Text = "Login ChiasmaDeposit";
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/ChiasmaDeposit/LoginWithBarCodeDialog.cs
+++ b/ChiasmaDeposit/LoginWithBarCodeDialog.cs
@@ -12,6 +12,8 @@ namespace Molmed.ChiasmaDep.Dialog
 {
     public partial class LoginWithBarcodeDialog : Form
     {
+        private delegate void BarcodeReceivedCallback(string barcode);
+
         private string MyBarcode;
         private int MyShrinkDistance;
 
@@ -59,9 +61,18 @@ namespace Molmed.ChiasmaDep.Dialog
 
         private void BarCodeReceived(string barcode)
         {
-            MyBarcode = barcode;
-            DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.Close();
+            if (InvokeRequired)
+            {
+                BarcodeReceivedCallback c = BarCodeReceived;
+                Invoke(c, barcode);
+            }
+            else
+            {
+                MyBarcode = barcode;
+                DialogResult = DialogResult.OK;
+                Close();
+            }
+
         }
 
         public string Barcode

--- a/ChiasmaDeposit/LoginWithBarCodeDialog.resx
+++ b/ChiasmaDeposit/LoginWithBarCodeDialog.resx
@@ -1,0 +1,138 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        AAABAAEAICAQAAAABADoAgAAFgAAACgAAAAgAAAAQAAAAAEABAAAAAAAAAIAAAAAAAAAAAAAEAAAABAA
+        AAAAAAAAAACAAACAAAAAgIAAgAAAAIAAgACAgAAAgICAAMDAwAAAAP8AAP8AAAD//wD/AAAA/wD/AP//
+        AAD///8AAAAAAADu7+7gAAzMbMz/AAAAAAAADu7+7gDMxszP8AAAAAAAAADu7+7szGzM/wAAAAAAAAAA
+        Du7+7sbMz/AAAAAAAAAAAADu7+7szP8AAAAAAAAAAAAADu7+7s/wAAAAAAAAAAAAAAzu7+7v8AAAAAAA
+        AAAAAADMzu7+7v8AAAAAAAAAAAAMzGzu7+7v8AAAAAAAAAAAzMbMzu7+7v8AAAAAAAAADMxswRHu7+7v
+        8AAAAAAAAMzGERERHu7+7v8AAAAAAAzBERERAADu7+7vAAAAAADMwREQAAAADu7+7/AAAAAMzGzMAAAA
+        ARHu7+7wAAAAzMbMwAAAERERHu7+8AAADMxszAABERERAMzu7vAAAOzGzMAREREQAAzMbu7wAA7ubMER
+        EREAAADMxszv8AAO7uERERAAAAAMzGzM/wAADv7uEQAAAAAAERbMz/AAAA7v7uAAAAABEREczP8AAAAA
+        7v7uAAAREREczM/wAAAAAO7v7uERERHMbMz/AAAAAAAO7v7uERDMxszP8AAAAAAAAO7v7uAMzGzM/wAA
+        AAAAAAAO7v7uzMbMz/AAAAAAAAAAAO7v7uxszP8AAAAAAAAAAAAO7v7uzM/wAAAAAAAAAAAAAO7v7uz/
+        AAAAAAAAAAAAAADO7v7u8AAAAAAAAAAAAAAMzO7v7u8AAAAAAAD/AHgD/4AwB//AAA//4AAf//AAP//4
+        AH//+AB///AAP//gAB//wAAP/4AAB/8AAAP+ADwD/AH+AfgD+AHwB8AB4A4DAcAQHgHAAPwBwAf4A8A/
+        8AfAf4APwDwAH+AAAD/gAQB/8AYA//gAAf/8AAP//gAH//8AD///gB///wAP/w==
+</value>
+  </data>
+</root>


### PR DESCRIPTION
Purpose:
Users can't login to ChiasmaDeposit by using the scanners in lab. The reason is that the scanners in lab have been reconfigured to not adding a crlf after the barcode being read. 

Implementation:
Adjust code for login from scanner. Trigger the login when number of chars equals the internal barcode length, instead of waiting for crlf. 